### PR TITLE
Fix generation on windows

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -45,7 +45,7 @@ plugins {
 }
 
 group = "com.github.utilx"
-version = "0.9.13"
+version = "0.9.14"
 
 repositories {
     mavenCentral()

--- a/playground/build.gradle
+++ b/playground/build.gradle
@@ -14,7 +14,7 @@ buildscript {
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files
-        classpath "com.github.utilx:android-assets-journalist:0.9.13"
+        classpath "com.github.utilx:android-assets-journalist:0.9.14"
     }
 }
 

--- a/src/main/kotlin/com/github/utilx/assetsjournalist/internal/CommonFunctions.kt
+++ b/src/main/kotlin/com/github/utilx/assetsjournalist/internal/CommonFunctions.kt
@@ -21,5 +21,5 @@ fun AndroidSourceSet.listAssets(): List<String> =
             val assetBaseDir = assetFileTree.dir
             assetFileTree.asFileTree.files
                 .map { it.relativeTo(assetBaseDir) }
-                .map { it.toString() }
+                .map { it.invariantSeparatorsPath }
         }


### PR DESCRIPTION
When journal is created on Windows host, path to assets in generated constants can contain '\' characters.