### PR TITLE
docs: update README plugin version guidance

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .gradle
 .idea
+.DS_Store
 build
 /out/
 

--- a/README.md
+++ b/README.md
@@ -63,10 +63,12 @@ AssetFiles.  // Press Ctrl+Space and see all assets
 
 ### 1. Apply the plugin
 
+The latest version is always shown by the Gradle Plugin badge above and on the [Gradle Plugin Portal][Gradle Plugin Portal].
+
 ```kotlin
 // build.gradle.kts (plugins block)
 plugins {
-    id("com.github.utilx.android-assets-journalist") version "1.0.0"
+    id("com.github.utilx.android-assets-journalist") version "<latest-version>"
 }
 ```
 


### PR DESCRIPTION
## Summary
- replace the hardcoded plugin version in `README.md` with a placeholder like `"<latest-version>"`
- point readers to the Gradle Plugin Portal badge as the source of the current published version
- ignore `.DS_Store` in `.gitignore`

## Testing
- not run

## Notes
- this PR includes the two committed changes on `docs/readme-update`
- the current working tree still has an unstaged `README.md` rewrite that is not included in this PR