### PR TITLE
docs: simplify README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Android Assets Journalist 🗂️
+# Android Assets Journalist
 
 [![Gradle Plugin](https://img.shields.io/maven-metadata/v/https/plugins.gradle.org/m2/com/github/utilx/android-assets-journalist/com.github.utilx.android-assets-journalist.gradle.plugin/maven-metadata.xml.svg?label=gradle)](https://plugins.gradle.org/plugin/com.github.utilx.android-assets-journalist)
 [![CI](https://github.com/karczews/android-assets-journalist/actions/workflows/ci.yml/badge.svg)](https://github.com/karczews/android-assets-journalist/actions/workflows/ci.yml)
@@ -6,108 +6,13 @@
 [![FOSSA Status](https://app.fossa.io/api/projects/git%2Bgithub.com%2Fkarczews%2Fandroid-assets-journalist.svg?type=shield)](https://app.fossa.io/projects/git%2Bgithub.com%2Fkarczews%2Fandroid-assets-journalist?ref=badge_shield)
 [![License](https://img.shields.io/badge/license-Apache%202.0-blue.svg)](https://github.com/karczews/android-assets-journalist/blob/main/LICENSE)
 
-**Stop using error-prone string paths. Get compile-time safety and IDE autocomplete for your Android assets.**
+Generate Kotlin constants or XML string resources from files in your Android `assets/` directories. Use generated names in code and keep raw asset paths out of call sites.
 
-Android Assets Journalist is a Gradle plugin that automatically generates type-safe constants for all your Android `assets/` files. No more typos, no more guessing paths, no more runtime crashes.
+## Example
 
-## The Problem 😫
+If your module contains:
 
-```kotlin
-// ❌ Error-prone string paths
-val modelPath = "models/tesorflow_lite_model.tflite"  // Oops, typo!
-val jsonPath = "configs/app_config.json"  // Where is this used? IDE can't find it
-
-// ❌ Runtime crashes when files are renamed or moved
-assets.open("old_path/file.json")  // Crash!
-
-// ❌ No autocomplete - you have to remember every path
-assets.open("???")  // Good luck remembering
-```
-
-## The Solution ✨
-
-```kotlin
-// ✅ Type-safe, generated constants
-val modelPath = AssetFiles.MODELS_TENSORFLOW_LITE_MODEL_TFLITE
-val jsonPath = AssetFiles.CONFIGS_APP_CONFIG_JSON
-
-// ✅ Refactor-safe rename support
-assets.open(AssetFiles.MODELS_TENSORFLOW_LITE_MODEL_TFLITE)  // IDE knows this!
-
-// ✅ Full IDE autocomplete support
-AssetFiles.  // Press Ctrl+Space and see all assets
-```
-
-## Perfect For 🎯
-
-- **🎮 Games** - Managing sprite sheets, audio files, level data, game assets
-- **🧠 Machine Learning** - TensorFlow Lite models, ONNX files, ML configs
-- **🌐 WebView Apps** - Local HTML, CSS, JavaScript files
-- **📄 Document Viewers** - PDF templates, custom fonts, document resources
-- **📦 Asset-Heavy Apps** - Any app with 10+ files in `assets/`
-- **🔧 Configuration-Heavy Apps** - JSON configs, XML schemas, property files
-
-## Why Choose Android Assets Journalist? 🏆
-
-| Feature | Benefit |
-|---------|---------|
-| **🔒 Compile-time safety** | Catch typos at build time, not runtime crashes |
-| **🤖 IDE autocomplete** | Press Ctrl+Space and see all your assets instantly |
-| **🔄 Refactoring support** | Rename assets safely - IDE updates all references |
-| **⚡ Zero runtime overhead** | Generated constants, no reflection or runtime cost |
-| **📱 AGP 8.x compatible** | Works with Android Gradle Plugin 8.8.0+ |
-| **🎨 Multiple output formats** | XML strings or Kotlin constants |
-| **⚙️ Highly configurable** | Prefixes, path transformations, filtering |
-
-## Quick Start 🚀
-
-### 1. Apply the plugin
-
-The latest version is always shown by the Gradle Plugin badge above and on the [Gradle Plugin Portal][Gradle Plugin Portal].
-
-```kotlin
-// build.gradle.kts (plugins block)
-plugins {
-    id("com.github.utilx.android-assets-journalist") version "<latest-version>"
-}
-```
-
-### 2. Configure (optional)
-
-```kotlin
-androidAssetsJournalist {
-    // Generate Kotlin constants (default: enabled)
-    kotlinFile {
-        enabled = true
-        className = "AssetFiles"
-        packageName = "com.yourcompany.yourapp"
-    }
-    
-    // Or Android string resources
-    xmlFile {
-        enabled = false
-    }
-}
-```
-
-### 3. Build and use
-
-```bash
-./gradlew assembleDebug
-```
-
-```kotlin
-import com.yourcompany.yourapp.AssetFiles
-
-// Access any asset with type-safe constants
-val model = AssetFiles.MODELS_ML_MODEL_TFLITE
-val config = AssetFiles.CONFIGS_SETTINGS_JSON
-```
-
-## Generated Output Examples 📄
-
-Given these assets:
-```
+```text
 src/main/assets/
 ├── models/
 │   └── ml_model.tflite
@@ -115,94 +20,174 @@ src/main/assets/
     └── settings.json
 ```
 
-### Kotlin Output
-```kotlin
-// AssetFiles.kt
-package com.github.utilx
+you can replace raw strings like this:
 
-object AssetFiles {
-    const val MODELS_ML_MODEL_TFLITE: String = "models/ml_model.tflite"
-    const val CONFIGS_SETTINGS_JSON: String = "configs/settings.json"
+```kotlin
+assets.open("models/ml_model.tflite")
+assets.open("configs/settings.json")
+```
+
+with generated constants:
+
+```kotlin
+import com.yourcompany.yourapp.assets.AssetFiles
+
+assets.open(AssetFiles.ASSET_MODELS_ML_MODEL_TFLITE_527533696)
+assets.open(AssetFiles.ASSET_CONFIGS_SETTINGS_JSON_2053859403)
+```
+
+Expect a hash suffix on each generated name. The suffix keeps names unique when two paths normalize to the same identifier.
+
+## Install
+
+The Gradle badge above and the [Gradle Plugin Portal][Gradle Plugin Portal] show the latest published version.
+
+Apply the plugin after `com.android.application` or `com.android.library` in the Android module that owns the `assets/` directory.
+
+```kotlin
+plugins {
+    id("com.android.application")
+    // or id("com.android.library")
+    id("com.github.utilx.android-assets-journalist") version "<latest-version>"
 }
 ```
 
-### XML Output
-```xml
-<!-- res/values/assets-strings.xml -->
-<resources>
-    <string name="models_ml_model_tflite">models/ml_model.tflite</string>
-    <string name="configs_settings_json">configs/settings.json</string>
-</resources>
-```
+## Configure Kotlin Output
 
-## Advanced Configuration ⚙️
-
-### Custom Prefixes
+If you leave both outputs disabled, the plugin generates Kotlin output. Unless you set `packageName`, it writes the generated file to `com.github.utilx`.
 
 ```kotlin
 androidAssetsJournalist {
     kotlinFile {
+        enabled = true
+        packageName = "com.yourcompany.yourapp.assets"
+        className = "AssetFiles"
+        constNamePrefix = "ASSET_"
+    }
+
+    xmlFile {
+        enabled = false
+    }
+}
+```
+
+## Configure XML Output
+
+Enable XML generation when you want Android string resources instead of Kotlin constants.
+
+```kotlin
+androidAssetsJournalist {
+    xmlFile {
+        enabled = true
+        stringNamePrefix = "asset_"
+    }
+
+    kotlinFile {
+        enabled = false
+    }
+}
+```
+
+## Build
+
+Run your usual Android build.
+
+```bash
+./gradlew assembleDebug
+```
+
+Gradle registers variant-aware tasks such as `generateAssetsKotlinFileDebug` and `generateAssetsXmlFileDebug`.
+
+You will find generated files under `build/generated/assetsjournalist/src/<variant>/`.
+
+## Generated Output
+
+With the Kotlin config above, you get:
+
+```kotlin
+package com.yourcompany.yourapp.assets
+
+object AssetFiles {
+    const val ASSET_MODELS_ML_MODEL_TFLITE_527533696 = "models/ml_model.tflite"
+    const val ASSET_CONFIGS_SETTINGS_JSON_2053859403 = "configs/settings.json"
+}
+```
+
+With XML output enabled, you get:
+
+```xml
+<resources>
+    <string name="asset_models_ml_model_tflite_527533696">models/ml_model.tflite</string>
+    <string name="asset_configs_settings_json_2053859403">configs/settings.json</string>
+</resources>
+```
+
+## Path Transforms And Value Prefixes
+
+Use `replaceInAssetsPath` when you want the generated name and value to use a transformed path.
+
+```kotlin
+androidAssetsJournalist {
+    kotlinFile {
+        enabled = true
+        replaceInAssetsPath = listOf(
+            mapOf("match" to "^dev_", "replaceWith" to "prod_")
+        )
+    }
+}
+```
+
+Use `constValuePrefix` when you need values such as `file:///android_asset/...`.
+
+```kotlin
+androidAssetsJournalist {
+    kotlinFile {
+        enabled = true
         className = "Assets"
-        packageName = "com.myapp.util"
+        packageName = "com.yourcompany.yourapp.assets"
         constNamePrefix = "ASSET_"
         constValuePrefix = "file:///android_asset/"
     }
 }
 ```
 
-**Output:**
 ```kotlin
-const val ASSET_MODELS_ML_MODEL_TFLITE: String = "file:///android_asset/models/ml_model.tflite"
+const val ASSET_MODELS_ML_MODEL_TFLITE_527533696 =
+    "file:///android_asset/models/ml_model.tflite"
 ```
 
-### Path Transformations
+## Configuration Reference
 
-```kotlin
-androidAssetsJournalist {
-    kotlinFile {
-        // Replace "dev_" prefix with "prod_" in generated paths
-        replaceInAssetsPath = [
-            [match: '^dev_', replaceWith: 'prod_']
-        ]
-    }
-}
-```
+`kotlinFile`
 
-## Configuration Reference 📖
+- `enabled`: turns Kotlin generation on or off
+- `className`: generated object name. Default `AssetFiles`
+- `packageName`: generated package name. Default `com.github.utilx`
+- `constNamePrefix`: prefix added before the sanitized path. Default `asset_`. The generator uppercases the final constant name.
+- `constValuePrefix`: prefix added to each generated value. Default `""`
+- `replaceInAssetsPath`: regex replacements applied before the plugin builds the generated name and value
 
-```kotlin
-androidAssetsJournalist {
-    // XML String Resources
-    xmlFile {
-        enabled = false  // Enable to generate res/values/*.xml
-        stringNamePrefix = "prefix_"
-    }
+`xmlFile`
 
-    // Kotlin Constants Object
-    kotlinFile {
-        enabled = false
-        className = "AssetFilesKt"
-        packageName = "com.github.utilx"
-        constNamePrefix = "asset_"
-        constValuePrefix = ""
-        replaceInAssetsPath = [
-            [match: '^dev_', replaceWith: 'prod_'],
-            [match: 'test_', replaceWith: '']
-        ]
-    }
-}
-```
+- `enabled`: turns XML generation on or off
+- `stringNamePrefix`: prefix added to each generated string resource name
 
-## Requirements ✅
+## Requirements
 
-- **Java**: 17 or higher
-- **Android Gradle Plugin**: 8.+ - Check given release notes for compatibility report.
-- **Gradle**: 8.+
-- **Kotlin**: 1.9.0 or higher (for Kotlin DSL)
+- Java 17 or newer
+- Gradle 8.0 or newer
+- Android Gradle Plugin 8.0.0 or newer
+- `namespace` set in your Android block when you use AGP 8+
 
+## Notes
+
+- Apply the plugin in the Android module that owns the `assets/` directory.
+- Each variant gets its own generated output directory.
+- The Kotlin generator removes duplicate entries after path transformation.
+- Examples in this README use Kotlin DSL.
 
 ## License
 
-[![FOSSA Status](https://app.fossa.io/api/projects/git%2Bgithub.com%2Fkarczews%2Fandroid-assets-journalist.svg?type=large)](https://app.fossa.io/projects/git%2Bgithub.com%2Fkarczews%2Fandroid-assets-journalist?ref=badge_large)
+Apache 2.0. See [LICENSE](LICENSE).
 
 [Gradle Plugin Portal]: <https://plugins.gradle.org/plugin/com.github.utilx.android-assets-journalist>


### PR DESCRIPTION
## Summary
- rewrite the README around a shorter install, configuration, and generated output flow
- remove marketing-heavy sections in favor of concrete usage examples and configuration reference
- keep version guidance tied to the Gradle badge and Plugin Portal instead of hardcoding a release

## Testing
- not run

## Notes
- this PR was created from the current local `README.md` rewrite only
- the change was uploaded to a new remote branch `docs/readme-simplify` from `main`